### PR TITLE
Fix canonicalization to correctly work for MS Outlook

### DIFF
--- a/lib/process-header.js
+++ b/lib/process-header.js
@@ -87,7 +87,7 @@ function processHeader( headers, signHeaders, method ) {
 
       // Remove signature value for "dkim-signature" header
       if( /^(dkim-signature|x-google-dkim-signature)/i.test( key ) ) {
-        value = value.replace( / b=(.*)$/, ' b=' )
+        value = value.replace( / b=([^;]*)/, ' b=' )
       }
 
       if( key === 'x-google-dkim-signature' ) {


### PR DESCRIPTION
Outlook places a semicolon at the end of the DKIM-Signature value, thus when replacing everything after `b=` till the end of the line, the signature becomes invalid.

Regexp is eager - in case of semicolon everything till semicolon is replaced and in case of no semicolon everything till the end is replaced, therefore IMHO no need for the trailing `$`.

Been banging my head the whole day today why my mails aren't DKIM verified ;)